### PR TITLE
Atualiza MAC do AP e renomeia variavel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-07-16 13:51 BRT
+- Renomeada variável `cMacAP` para `cmac_ap` e atualizada em todo o código.
+- `cmac_ap` agora recebe o MAC do AP em `beginConnection()`.
+
 
 ## 2025-07-04 18:23 UTC
 - Corrigido caminho remoto do OTA para o usuário `andre-beautomacao`.

--- a/network_mqtt.cpp
+++ b/network_mqtt.cpp
@@ -26,7 +26,7 @@ extern volatile bool eth_connected;
 extern volatile bool mqtt_connected;
 extern volatile uint8_t mqttPreferencia;
 extern volatile uint8_t mqtt_interface;
-extern char cMacAP[];
+extern char cmac_ap[];
 extern char cMacETH[];
 extern AsyncMqttClient mqttClient;
 extern PCF8574 pcf8574_R1;
@@ -92,7 +92,7 @@ void sendDeviceMessage(const String& mensagem) {
   }
 
   DynamicJsonDocument doc(256);
-  doc["mac"] = cMacAP;
+  doc["mac"] = cmac_ap;
   doc["ip"] = ip;
   doc["mensagem"] = mensagem;
 
@@ -140,6 +140,7 @@ void beginConnection() {
   delay(100);  // Pequeno delay para garantir inicialização
   mac_ap = WiFi.softAPmacAddress(); // Ex: "14:33:5C:45:08:7D"
   mac_ap.replace(":", "");          // Ex: "14335C45087D"
+  mac_ap.toCharArray(cmac_ap, sizeof(cmac_ap));
 
   // 3. Monte o SSID definitivo
   apSSID += "_" + mac_ap;
@@ -304,7 +305,7 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
       return;
     }
     const char* macReceived = doc["mac"];
-    if (strcmp(macReceived, cMacAP) == 0) {
+    if (strcmp(macReceived, cmac_ap) == 0) {
       if (doc.containsKey("ssid")) updateWifiSSIDInEEPROM(doc["ssid"]);
       if (doc.containsKey("senha")) updateWifiPassInEEPROM(doc["senha"]);
       if (doc.containsKey("mqtt_server")) updateMqttServerInEEPROM(doc["mqtt_server"]);
@@ -335,7 +336,7 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
     return;
   }
   const char* macReceived = doc["mac"];
-  if (strcmp(macReceived, cMacAP) == 0) {
+  if (strcmp(macReceived, cmac_ap) == 0) {
     if (strcmp(topic, "qipi/update") == 0) {
       LOG_OTA("Nova atualização disponível");
       delay(2000);

--- a/qipi-a8.ino
+++ b/qipi-a8.ino
@@ -153,7 +153,7 @@ const char* http_username = HTTP_USER_DEFAULT;
 const char* http_password = HTTP_PASS_DEFAULT;
 
 
-char cMacAP[20];
+char cmac_ap[20];
 char cMacSTA[20];
 char cMacETH[20];
 
@@ -722,7 +722,7 @@ void publishAllInputs1() {
     return;
   }
   DynamicJsonDocument doc(512);
-  doc["mac"] = cMacAP;
+  doc["mac"] = cmac_ap;
   doc["ph"] = roundf(ph * 100.0f) / 100.0f;
   doc["orp"] = roundf(orp);
   doc["adc1"] = adc1_val;
@@ -761,7 +761,7 @@ void publishDigitalGroup1() {
     return;
   }
   DynamicJsonDocument doc(256);
-  doc["mac"] = cMacAP;  // usa cMacAP para identificar o primeiro dispositivo
+  doc["mac"] = cmac_ap;  // usa cmac_ap para identificar o primeiro dispositivo
   // Entradas digitais 1 a 8
   doc["di01"] = di01State;
   doc["di02"] = di02State;
@@ -786,7 +786,7 @@ void publishAnalogGroup1() {
     return;
   }
   DynamicJsonDocument doc(256);
-  doc["mac"] = cMacAP;
+  doc["mac"] = cmac_ap;
   // Dados analógicos para dispositivo 1
   doc["ph"] = roundf(ph * 100.0f) / 100.0f;
   doc["orp"] = roundf(orp);
@@ -807,7 +807,7 @@ void publishTemperatures() {
   }
 
   DynamicJsonDocument doc(256);
-  doc["mac"] = cMacAP;
+  doc["mac"] = cmac_ap;
   doc["t1"] = temperatura1;
   //doc["t3"] = temperatura3;
 
@@ -1205,7 +1205,7 @@ void checkSerialCommands() {
     }
 
     const char* macReceived = doc["mac"];
-    if (strcmp(macReceived, cMacAP) == 0) {
+    if (strcmp(macReceived, cmac_ap) == 0) {
       if (doc.containsKey("ssid")) updateWifiSSIDInEEPROM(String(doc["ssid"]).c_str());
       if (doc.containsKey("senha")) updateWifiPassInEEPROM(String(doc["senha"]).c_str());
       if (doc.containsKey("mqtt_server")) updateMqttServerInEEPROM(String(doc["mqtt_server"]).c_str());

--- a/web_server.cpp
+++ b/web_server.cpp
@@ -23,7 +23,7 @@ extern bool mqtt_retain;
 extern unsigned long sensorInterval;
 extern unsigned long publishInterval;
 extern volatile bool mqtt_connected;
-extern char cMacAP[];
+extern char cmac_ap[];
 
 // Sensor and I/O values
 extern float ph, orp, temperatura1;
@@ -389,7 +389,7 @@ void serverRoutes() {
     DynamicJsonDocument doc(768);  // aumenta um pouco o buffer
 
     // Campos antigos (já existentes)
-    doc["mac_wifi"] = cMacAP;
+    doc["mac_wifi"] = cmac_ap;
     doc["nome"] = mqttClientId;
     doc["ssid"] = wifiSSID;
     doc["senha"] = wifiPass;
@@ -468,7 +468,7 @@ void serverRoutes() {
       }
       // Comentei a verificação do MAC para evitar erro ao enviar em branco!
       // const char* macReceived = doc["mac"];
-      // if (strcmp(macReceived, cMacAP) != 0 && strcmp(macReceived, cMacAP2) != 0) {
+      // if (strcmp(macReceived, cmac_ap) != 0 && strcmp(macReceived, cmac_ap2) != 0) {
       //   request->send(403, "application/json", "{\"error\":\"MAC não corresponde\"}");
       //   return;
       // }
@@ -512,7 +512,7 @@ void serverRoutes() {
 
   server.on("/statusRede", HTTP_GET, [](AsyncWebServerRequest* request) {
     DynamicJsonDocument doc(512);
-    doc["mac_wifi"] = cMacAP;
+    doc["mac_wifi"] = cmac_ap;
     doc["ssid"] = wifiSSID;
     doc["senha"] = wifiPass;
     if (WiFi.status() == WL_CONNECTED) {


### PR DESCRIPTION
## Summary
- rename `cMacAP` to `cmac_ap`
- fill `cmac_ap` with the AP MAC during network setup
- update code references in MQTT, web server, and main sketch
- document change in changelog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877d6ffc4ac8327bcfe1bf04fe74a1a