### PR TITLE
Fix OTA update disk space issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## 2025-07-16 14:27 BRT
+- Removido o arquivo de firmware do LittleFS antes do download e apos uma atualizacao OTA bem-sucedida para evitar falta de espaco.
+
 ## 2025-07-16 13:59 BRT
 - Corrigida declaracao de `cmac_ap` com tamanho fixo para uso de `sizeof()`.
 

--- a/qipi-a8.ino
+++ b/qipi-a8.ino
@@ -824,6 +824,8 @@ void publishTemperatures() {
 void getFileFromServer() {
   WiFiClientSecure client;
   client.setInsecure();
+  // Remove any previous firmware file to free space for the new download
+  LittleFS.remove("/" + String(FILE_NAME));
   if (client.connect(REMOTEHOST, REMOTEPORT)) {
     LOG_OTA("Connected to server");
     client.print("GET " + String(REMOTEPATH) + " HTTP/1.1\r\n");
@@ -884,12 +886,14 @@ void performOTAUpdateFromLittleFS() {
   Update.writeStream(file);
   if (Update.end()) {
     LOG_OTA("Successful update");
+    file.close();
+    // Delete the firmware file to free space after a successful update
+    LittleFS.remove("/" + String(FILE_NAME));
   } else {
     LOG_OTA("Error Occurred: " + String(Update.getError()));
     file.close();
     return;
   }
-  file.close();
   LOG_OTA("Reset in 4 seconds....");
   delay(4000);
   ETH.end();  // libera o driver


### PR DESCRIPTION
## Summary
- ensure old firmware is deleted before new OTA download
- clean up the firmware file after successful OTA
- document the fix in the changelog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877dead2650832795cc4b11c464e82d