### PR TITLE
Implement HTTP status validation for OTA update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-07-16 16:53 BRT
+- Verifica o status HTTP do firmware durante o download; se não for 200, a atualização é abortada.
+
+
 ## 2025-07-16 16:50 BRT
 - Removida `TaskOTA` e a biblioteca `ElegantOTA` por não utilizar mais OTA via web.
 

--- a/qipi-a8.ino
+++ b/qipi-a8.ino
@@ -831,6 +831,23 @@ void updateFirmwareFromServer() {
   client.println("Connection: close\r\n");
   client.println();
 
+  // Read the HTTP status line
+  String statusLine = client.readStringUntil('\n');
+  statusLine.trim();
+  int statusCode = 0;
+  if (statusLine.startsWith("HTTP/")) {
+    int firstSpace = statusLine.indexOf(' ');
+    int secondSpace = statusLine.indexOf(' ', firstSpace + 1);
+    if (firstSpace > 0 && secondSpace > firstSpace) {
+      statusCode = statusLine.substring(firstSpace + 1, secondSpace).toInt();
+    }
+  }
+  if (statusCode != 200) {
+    LOG_PRINTF("[OTA] HTTP status: %s\n", statusLine.c_str());
+    client.stop();
+    return;
+  }
+
   bool inHeaders = true;
   int contentLength = 0;
   String line;


### PR DESCRIPTION
## Summary
- check HTTP status code when downloading firmware
- document new OTA safety check in changelog

## Testing
- `make` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_687802f3695483279ebe8f14eddc4a6f