### PR TITLE
Enhance OTA logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Changelog
+## 2025-07-16 17:26 BRT
+- Loga a linha de status HTTP imediatamente apos a leitura e aborta com mensagem se o status nao for 200.
+- Envio do cabecalho HTTP sem linha extra em branco.
+
 
 ## 2025-07-16 16:53 BRT
 - Verifica o status HTTP do firmware durante o download; se não for 200, a atualização é abortada.

--- a/qipi-a8.ino
+++ b/qipi-a8.ino
@@ -828,12 +828,13 @@ void updateFirmwareFromServer() {
 
   client.print(String("GET ") + REMOTEPATH + " HTTP/1.1\r\n");
   client.print(String("Host: ") + REMOTEHOST + "\r\n");
-  client.println("Connection: close\r\n");
+  client.print("Connection: close\r\n");
   client.println();
 
   // Read the HTTP status line
   String statusLine = client.readStringUntil('\n');
   statusLine.trim();
+  LOG_PRINTF("[OTA] HTTP status: %s\n", statusLine.c_str());
   int statusCode = 0;
   if (statusLine.startsWith("HTTP/")) {
     int firstSpace = statusLine.indexOf(' ');
@@ -843,7 +844,7 @@ void updateFirmwareFromServer() {
     }
   }
   if (statusCode != 200) {
-    LOG_PRINTF("[OTA] HTTP status: %s\n", statusLine.c_str());
+    LOG_OTA("Aborting OTA due to HTTP status " + statusLine);
     client.stop();
     return;
   }


### PR DESCRIPTION
## Summary
- log the HTTP status line when downloading firmware
- abort OTA with a message showing the HTTP status line when not 200
- avoid double newlines in HTTP request headers
- add São Paulo dated changelog entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68780ab82694832792cb1ab970f60815